### PR TITLE
feat: support request form + billing page UX fixes

### DIFF
--- a/.github/workflows/publish-frontend.yml
+++ b/.github/workflows/publish-frontend.yml
@@ -5,11 +5,11 @@ on:
     branches:
       - main
     paths:
-      - 'src/**'
-      - 'public/**'
-      - 'package.json'
-      - 'Dockerfile'
-      - '.github/workflows/publish-frontend.yml'
+      - "src/**"
+      - "public/**"
+      - "package.json"
+      - "Dockerfile"
+      - ".github/workflows/publish-frontend.yml"
   workflow_dispatch:
 
 jobs:
@@ -47,8 +47,8 @@ jobs:
             NEXT_PUBLIC_PAYMENT_CURRENCY=${{ vars.NEXT_PUBLIC_PAYMENT_CURRENCY || 'USD' }}
             NEXT_PUBLIC_CREDIT_DEFAULT_AMOUNT=${{ vars.NEXT_PUBLIC_CREDIT_DEFAULT_AMOUNT || '10' }}
             NEXT_PUBLIC_CREDIT_MIN_AMOUNT=${{ vars.NEXT_PUBLIC_CREDIT_MIN_AMOUNT || '1' }}
-            NEXT_PUBLIC_BYOK_MONTHLY_PRICE=${{ vars.NEXT_PUBLIC_BYOK_MONTHLY_PRICE || '10' }}
-            NEXT_PUBLIC_BYOK_YEARLY_PRICE=${{ vars.NEXT_PUBLIC_BYOK_YEARLY_PRICE || '100' }}
+            NEXT_PUBLIC_BYOK_MONTHLY_PRICE=${{ vars.NEXT_PUBLIC_BYOK_MONTHLY_PRICE || '1' }}
+            NEXT_PUBLIC_BYOK_YEARLY_PRICE=${{ vars.NEXT_PUBLIC_BYOK_YEARLY_PRICE || '2' }}
             NEXT_PUBLIC_BYOK_PRORATION_INTERVAL_DAYS=${{ vars.NEXT_PUBLIC_BYOK_PRORATION_INTERVAL_DAYS || '30' }}
             NEXT_PUBLIC_FEE_TIERS=${{ vars.NEXT_PUBLIC_FEE_TIERS || '5-20:35,21-50:30,51-100:25,101+:20' }}
           cache-from: type=gha

--- a/src/actions/support-messages-actions.ts
+++ b/src/actions/support-messages-actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { fetchAuthedJson, fetchAuthed, buildApiUrl } from "@/lib/api-client";
+import { fetchAuthedJson, buildApiUrl } from "@/lib/api-client";
 
 type SupportCreateData = {
   fullname: string;
@@ -12,18 +12,20 @@ type SupportCreateData = {
 
 export async function createSupportMessage(formData: SupportCreateData) {
   try {
-    const url = buildApiUrl('/support');
+    const url = buildApiUrl('/support/');
     const response = await fetchAuthedJson(url, {
       method: 'POST',
       body: JSON.stringify(formData),
     });
 
-    //   if (!response.ok) {
-    //     throw new Error('Support Message not sent');
-    //   }
-    alert('Message successfully sent!')
-    return await response.json();
+    if (!response.ok) {
+      const detail = await response.text();
+      return { ok: false, error: detail || `Request failed (${response.status})` };
+    }
+    const data = await response.json();
+    return { ok: true, data };
   } catch (error) {
-    console.log('Error', error)
+    console.log('Error', error);
+    return { ok: false, error: 'Server Error' };
   }
 }

--- a/src/components/Billing.tsx
+++ b/src/components/Billing.tsx
@@ -162,10 +162,12 @@ export default function Billing({ sub_id, t_id, subPlan, subAmount, subInterval,
           <span className="font-medium">Amount:</span>
           <span className="font-semibold">{subCurrency}{subAmount}</span>
         </div>
-        <div className="flex justify-between">
-          <span className="font-medium">Billing Interval:</span>
-          <span className="capitalize">{subInterval}</span>
-        </div>
+        {!['gyok', 'topup'].includes(subPlan?.toLowerCase()) && (
+          <div className="flex justify-between">
+            <span className="font-medium">Billing Interval:</span>
+            <span className="capitalize">{subInterval}</span>
+          </div>
+        )}
         <div className="flex justify-between">
           <span className="font-medium">Next Billing Date:</span>
           <span className="capitalize">
@@ -256,8 +258,7 @@ export default function Billing({ sub_id, t_id, subPlan, subAmount, subInterval,
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Invoice</th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Plan</th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Amount</th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Start Date</th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">End Date</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Period</th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
               </tr>
             </thead>
@@ -266,6 +267,11 @@ export default function Billing({ sub_id, t_id, subPlan, subAmount, subInterval,
                 const isExpired = new Date(tx.end_date) < new Date();
                 let status = tx.status || (isExpired ? 'completed' : 'active');
                 if (status === 'active' && isExpired) status = 'completed';
+
+                const isOneTime = ['gyok', 'topup'].includes(tx.plan_name?.toLowerCase());
+                const period = isOneTime
+                  ? 'One-time'
+                  : `${new Date(tx.start_date).toLocaleDateString()} – ${new Date(tx.end_date).toLocaleDateString()}`;
 
                 return (
                   <tr key={tx.id}>
@@ -283,10 +289,7 @@ export default function Billing({ sub_id, t_id, subPlan, subAmount, subInterval,
                       {tx.currency} {parseFloat(tx.amount).toLocaleString()}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      {new Date(tx.start_date).toLocaleDateString()}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      {new Date(tx.end_date).toLocaleDateString()}
+                      {period}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm">
                       <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full
@@ -301,7 +304,7 @@ export default function Billing({ sub_id, t_id, subPlan, subAmount, subInterval,
               })}
               {!historyData?.transactions?.length && (
                 <tr>
-                  <td colSpan={6} className="px-6 py-4 text-center text-sm text-gray-500">No transactions found</td>
+                  <td colSpan={5} className="px-6 py-4 text-center text-sm text-gray-500">No transactions found</td>
                 </tr>
               )}
             </tbody>

--- a/src/components/Billing.tsx
+++ b/src/components/Billing.tsx
@@ -140,18 +140,20 @@ export default function Billing({ sub_id, t_id, subPlan, subAmount, subInterval,
     <div className="max-w-2xl mx-auto py-12 px-4">
       <div className="mb-6 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 sm:gap-0">
         <h1 className="text-2xl font-bold">Billing & Subscription</h1>
-        {isActive ?
-          (
-            <div className="border border-green-600 px-4 py-2 rounded-lg">
-              <h1 className="text-green-600 bold">Active</h1>
-            </div>
-          ) : (
-            <button
-              onClick={() => handleActivateSubscription(sub_id)}
-              className="mt-4 bg-green-600 hover:bg-green-700 text-white rounded-lg px-4 py-2">
-              {isActivating ? 'Reactivating...' : 'Reactivate'}
-            </button>
-          )}
+        {!['gyok', 'topup'].includes(subPlan?.toLowerCase()) && (
+          isActive ?
+            (
+              <div className="border border-green-600 px-4 py-2 rounded-lg">
+                <h1 className="text-green-600 bold">Active</h1>
+              </div>
+            ) : (
+              <button
+                onClick={() => handleActivateSubscription(sub_id)}
+                className="mt-4 bg-green-600 hover:bg-green-700 text-white rounded-lg px-4 py-2">
+                {isActivating ? 'Reactivating...' : 'Reactivate'}
+              </button>
+            )
+        )}
       </div>
       <div className="bg-white shadow-md rounded-lg p-6 space-y-4">
         <div className="flex justify-between">

--- a/src/components/BillingConfig.tsx
+++ b/src/components/BillingConfig.tsx
@@ -92,6 +92,7 @@ export default function BillingConfig({ initialConfig, allModels, currentPlan, c
     const [provider, setProvider] = useState(initialConfig?.byok_provider || 'openrouter');
 
     const isByokSubscribed = currentSubscriptionTier === 'byok';
+    const isViewingCurrentTier = billingType === currentSubscriptionTier;
     const [billingCycle, setBillingCycle] = useState<'monthly' | 'yearly'>('monthly');
 
 
@@ -312,9 +313,8 @@ export default function BillingConfig({ initialConfig, allModels, currentPlan, c
 
     const handleBillingTypeChange = (type: 'standard' | 'byok' | 'managed') => {
         setBillingType(type);
-        // Clear previous model selections when switching types
-        setPreferredModels([]);
-        setDefaultModel('');
+        // Preserve user's preferred-model selections across tab switches;
+        // they only render on the tier they belong to (see isViewingCurrentTier).
         setProviderModels([]);
         setModelsFetchError(null);
         // Reset search term for fresh start
@@ -918,7 +918,7 @@ export default function BillingConfig({ initialConfig, allModels, currentPlan, c
 
 
                         {/* Warning when no models selected */}
-                        {(billingType === 'byok' || billingType === 'managed') && isKeyVerified && preferredModels.length === 0 && (
+                        {(billingType === 'byok' || billingType === 'managed') && isKeyVerified && isViewingCurrentTier && preferredModels.length === 0 && (
                             <div className="mb-4 p-4 bg-amber-50 border border-amber-200 rounded-lg animate-pulse">
                                 <div className="flex items-start gap-3">
                                     <svg className="h-5 w-5 text-amber-600 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
@@ -934,7 +934,7 @@ export default function BillingConfig({ initialConfig, allModels, currentPlan, c
 
 
                         {/* Only show Preferred Models section when not loading and no error */}
-                        {(!isLoadingModels || billingType !== 'byok') && !modelsFetchError && isKeyVerified && (
+                        {(!isLoadingModels || billingType !== 'byok') && !modelsFetchError && isKeyVerified && isViewingCurrentTier && (
                             <button
                                 onClick={async () => {
                                     const isOpening = !isModelsOpen;
@@ -988,7 +988,7 @@ export default function BillingConfig({ initialConfig, allModels, currentPlan, c
                         )}
 
 
-                        {isModelsOpen && !modelsFetchError && (
+                        {isModelsOpen && !modelsFetchError && isViewingCurrentTier && (
                             <div className="animate-in fade-in slide-in-from-top-2 duration-300">
                                 <p className="text-xs text-gray-500 mb-4">
                                     Search and select any OpenRouter models you want to use. You must select a Default Model to save changes.

--- a/src/components/Demo.tsx
+++ b/src/components/Demo.tsx
@@ -1,24 +1,92 @@
 'use client'
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Image from "next/image";
+import { useForm } from "react-hook-form";
+import { createSupportMessage } from "@/actions/support-messages-actions";
+import { messageType, messageTypeEnum } from "@/types";
+import Alert from "@/components/ui/Alert";
+import LoadingSpinner from "@/components/ui/LoadingSpinner";
+
+type SupportFormData = {
+    fullname: string;
+    email: string;
+    subject: string;
+    message: string;
+}
+
+export const REQUEST_DEMO_EVENT = "daxno:request-demo";
 
 export default function Demo() {
     const [isOuterExpanded, setIsOuterExpanded] = useState(false);
     const [isInnerVisible, setIsInnerVisible] = useState(false);
     const [isTextVisible, setIsTextVisible] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const [message, setMessage] = useState<messageType | null>(null);
+    const isOpenRef = useRef(false);
+
+    const {
+        register,
+        handleSubmit,
+        reset,
+        formState: { errors },
+    } = useForm<SupportFormData>();
+
+    const openOverlay = useCallback(() => {
+        if (isOpenRef.current) return;
+        isOpenRef.current = true;
+        setIsOuterExpanded(true);
+        setTimeout(() => {
+            setIsInnerVisible(true);
+            setIsTextVisible(true);
+        }, 800);
+    }, []);
+
+    const closeOverlay = useCallback(() => {
+        if (!isOpenRef.current) return;
+        isOpenRef.current = false;
+        setIsTextVisible(false);
+        setTimeout(() => setIsInnerVisible(false), 300);
+        setTimeout(() => setIsOuterExpanded(false), 600);
+    }, []);
 
     const toggleExpand = () => {
-        if (isOuterExpanded) {
-            setIsTextVisible(false);
-            setTimeout(() => setIsInnerVisible(false), 300);
-            setTimeout(() => setIsOuterExpanded(false), 600);
+        if (isOpenRef.current) {
+            closeOverlay();
         } else {
-            setIsOuterExpanded(true);
-            setTimeout(() => {
-                setIsInnerVisible(true);
-                setIsTextVisible(true);
-            }, 800);
+            openOverlay();
+        }
+    };
+
+    useEffect(() => {
+        const handler = () => openOverlay();
+        window.addEventListener(REQUEST_DEMO_EVENT, handler);
+        return () => window.removeEventListener(REQUEST_DEMO_EVENT, handler);
+    }, [openOverlay]);
+
+    const onSubmit = async (data: SupportFormData) => {
+        setIsLoading(true);
+        try {
+            const result = await createSupportMessage(data);
+            if (result?.ok) {
+                setMessage({
+                    type: messageTypeEnum.SUCCESS,
+                    text: "Thanks! Your request was sent. We'll be in touch shortly.",
+                });
+                reset();
+            } else {
+                setMessage({
+                    type: messageTypeEnum.ERROR,
+                    text: result?.error || "Failed to send your request. Please try again.",
+                });
+            }
+        } catch {
+            setMessage({
+                type: messageTypeEnum.ERROR,
+                text: "Server Error",
+            });
+        } finally {
+            setIsLoading(false);
         }
     };
 
@@ -30,7 +98,7 @@ export default function Demo() {
                         onClick={toggleExpand}
                         className="w-full border-2 border-blue-600 text-blue-600 font-medium py-2.5 md:py-3 px-6 md:px-8 rounded-lg transition-all hover:bg-blue-50 text-sm md:text-base"
                     >
-                        Watch Demo
+                        Request Demo
                     </button>
                 </div>
             </div>
@@ -42,14 +110,15 @@ export default function Demo() {
                     left: isOuterExpanded ? 0 : "50px",
                     width: isOuterExpanded ? "100%" : "0px",
                     height: isOuterExpanded ? "100%" : "0px",
-                    backgroundColor: isOuterExpanded ? "rgba(0, 0, 0, 0.5)" : "transparent", // semi-transparent dark
-                    backdropFilter: isOuterExpanded ? "blur(4px)" : "none", // optional blur
+                    backgroundColor: isOuterExpanded ? "rgba(0, 0, 0, 0.5)" : "transparent",
+                    backdropFilter: isOuterExpanded ? "blur(4px)" : "none",
                     transition: "all 0.8s ease",
                     zIndex: 1000,
                     display: "flex",
                     flexDirection: "column",
                     alignItems: "center",
                     justifyContent: "center",
+                    overflowY: "auto",
                 }}
             >
                 {isOuterExpanded && (
@@ -57,6 +126,7 @@ export default function Demo() {
                         style={{
                             alignSelf: "flex-end",
                             marginRight: "20px",
+                            cursor: "pointer",
                         }}
                         onClick={toggleExpand}
                     >
@@ -64,36 +134,127 @@ export default function Demo() {
                     </div>
                 )}
 
-                <div className={`text-center mb-12 transition-opacity duration-300 ${isTextVisible ? 'opacity-100' : 'opacity-0'}`}>
-                    <h2 className="text-3xl font-bold text-gray-900 mb-4">
-                        See It in Action
+                {message && <Alert message={message} onClose={() => setMessage(null)} />}
+
+                <div className={`text-center mb-8 transition-opacity duration-300 ${isTextVisible ? 'opacity-100' : 'opacity-0'}`}>
+                    <h2 className="text-3xl font-bold text-white mb-4">
+                        Request a Demo
                     </h2>
-                    <p className="text-gray-600 max-w-2xl mx-auto">
-                        Watch how TheWings AI transforms document processing in 90 seconds
+                    <p className="text-gray-200 max-w-2xl mx-auto px-4">
+                        Tell us a bit about you and we&apos;ll reach out to schedule a personalized walkthrough.
                     </p>
                 </div>
 
                 <div
-                    className=" w-full md:w-4/5 transform origin-top transition-transform duration-500 flex flex-col items-stretch justify-start"
+                    className="w-full md:w-2/3 lg:w-1/2 transform origin-top transition-transform duration-500 flex flex-col items-stretch justify-start"
                     style={{
                         transform: isInnerVisible ? "scaleY(1)" : "scaleY(0)",
                     }}
                 >
                     {isInnerVisible && (
                         <div className="w-full mx-auto px-4">
-                            <div className="relative aspect-video rounded-2xl shadow-xl overflow-hidden">
-                                <iframe 
-                                   width="100%" 
-                                   height="100%" 
-                                   src="https://www.youtube.com/embed/OcjhoReRTYE?si=GTLdXpCdEckgVtBl" 
-                                   title="YouTube video player" 
-                                   frameBorder="0" 
-                                   allow="accelerometer; 
-                                   autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
-                                   referrerPolicy="strict-origin-when-cross-origin" 
-                                   allowFullScreen>
-                                   </iframe>
-                            </div>
+                            {/*
+                                Previously displayed a YouTube demo video:
+                                <div className="relative aspect-video rounded-2xl shadow-xl overflow-hidden">
+                                    <iframe
+                                       width="100%"
+                                       height="100%"
+                                       src="https://www.youtube.com/embed/OcjhoReRTYE?si=GTLdXpCdEckgVtBl"
+                                       title="YouTube video player"
+                                       frameBorder="0"
+                                       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                                       referrerPolicy="strict-origin-when-cross-origin"
+                                       allowFullScreen>
+                                    </iframe>
+                                </div>
+                            */}
+                            <form
+                                onSubmit={handleSubmit(onSubmit)}
+                                className="bg-white rounded-2xl shadow-xl p-6 md:p-8 space-y-4"
+                            >
+                                <div>
+                                    <label htmlFor="fullname" className="block text-sm font-medium text-gray-700 mb-1">
+                                        Full name
+                                    </label>
+                                    <input
+                                        id="fullname"
+                                        type="text"
+                                        disabled={isLoading}
+                                        {...register("fullname", { required: "Full name is required" })}
+                                        className={`w-full px-3 py-2.5 bg-white border ${errors.fullname ? 'border-red-300 focus:ring-red-200' : 'border-gray-300 focus:border-blue-500 focus:ring-blue-100'} rounded-lg text-gray-800 placeholder-gray-400 focus:outline-none focus:ring-2 transition-all`}
+                                        placeholder="Jane Doe"
+                                    />
+                                    {errors.fullname && (
+                                        <p className="text-red-500 text-xs mt-1">{errors.fullname.message}</p>
+                                    )}
+                                </div>
+
+                                <div>
+                                    <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+                                        Work email
+                                    </label>
+                                    <input
+                                        id="email"
+                                        type="email"
+                                        disabled={isLoading}
+                                        {...register("email", {
+                                            required: "Email is required",
+                                            pattern: {
+                                                value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                                                message: "Invalid email address",
+                                            },
+                                        })}
+                                        className={`w-full px-3 py-2.5 bg-white border ${errors.email ? 'border-red-300 focus:ring-red-200' : 'border-gray-300 focus:border-blue-500 focus:ring-blue-100'} rounded-lg text-gray-800 placeholder-gray-400 focus:outline-none focus:ring-2 transition-all`}
+                                        placeholder="jane@company.com"
+                                    />
+                                    {errors.email && (
+                                        <p className="text-red-500 text-xs mt-1">{errors.email.message}</p>
+                                    )}
+                                </div>
+
+                                <div>
+                                    <label htmlFor="subject" className="block text-sm font-medium text-gray-700 mb-1">
+                                        Subject
+                                    </label>
+                                    <input
+                                        id="subject"
+                                        type="text"
+                                        disabled={isLoading}
+                                        {...register("subject", { required: "Subject is required" })}
+                                        className={`w-full px-3 py-2.5 bg-white border ${errors.subject ? 'border-red-300 focus:ring-red-200' : 'border-gray-300 focus:border-blue-500 focus:ring-blue-100'} rounded-lg text-gray-800 placeholder-gray-400 focus:outline-none focus:ring-2 transition-all`}
+                                        placeholder="Demo request"
+                                        defaultValue="Demo request"
+                                    />
+                                    {errors.subject && (
+                                        <p className="text-red-500 text-xs mt-1">{errors.subject.message}</p>
+                                    )}
+                                </div>
+
+                                <div>
+                                    <label htmlFor="message" className="block text-sm font-medium text-gray-700 mb-1">
+                                        Message
+                                    </label>
+                                    <textarea
+                                        id="message"
+                                        rows={4}
+                                        disabled={isLoading}
+                                        {...register("message", { required: "Message is required" })}
+                                        className={`w-full px-3 py-2.5 bg-white border ${errors.message ? 'border-red-300 focus:ring-red-200' : 'border-gray-300 focus:border-blue-500 focus:ring-blue-100'} rounded-lg text-gray-800 placeholder-gray-400 focus:outline-none focus:ring-2 transition-all resize-none`}
+                                        placeholder="Tell us about your team, use-case, or what you'd like to see."
+                                    />
+                                    {errors.message && (
+                                        <p className="text-red-500 text-xs mt-1">{errors.message.message}</p>
+                                    )}
+                                </div>
+
+                                <button
+                                    type="submit"
+                                    disabled={isLoading}
+                                    className={`w-full py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white font-medium rounded-lg shadow transition duration-200 flex items-center justify-center ${isLoading ? 'cursor-not-allowed' : ''}`}
+                                >
+                                    {isLoading ? <LoadingSpinner /> : "Send request"}
+                                </button>
+                            </form>
                         </div>
                     )}
                 </div>

--- a/src/components/header/CurrentPlan.tsx
+++ b/src/components/header/CurrentPlan.tsx
@@ -28,7 +28,7 @@ export default function CurrentPlan({ transactions, billingConfig }: CurrentPlan
         {(transactions[0]?.plan_name === 'Professional' || transactions[0]?.plan_name === 'Starter') && <Link href='/billing' className='block md:hidden underline hover:text-blue-500'>Billing</Link>}
         <div className="flex justify-end">
           <Link
-            href="/billing?tab=configuration&option=byok"
+            href="/billing?tab=configuration"
             className="flex items-center gap-1 text-blue-600 hover:text-blue-700 cursor-pointer"
           >
             <Crown className="w-4 h-4" />

--- a/src/components/landing/CTABanner.tsx
+++ b/src/components/landing/CTABanner.tsx
@@ -3,6 +3,7 @@
 import { motion } from "framer-motion";
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
+import { REQUEST_DEMO_EVENT } from "@/components/Demo";
 
 export default function CTABanner() {
   return (
@@ -63,7 +64,11 @@ export default function CTABanner() {
                 Create your free account
                 <ArrowRight size={16} className="transition-transform group-hover:translate-x-1" />
               </Link>
-              <button className="text-sm text-white/50 transition-colors hover:text-white">
+              <button
+                type="button"
+                onClick={() => window.dispatchEvent(new CustomEvent(REQUEST_DEMO_EVENT))}
+                className="text-sm text-white/50 transition-colors hover:text-white"
+              >
                 Schedule a demo →
               </button>
               <div className="text-xs text-white/30">


### PR DESCRIPTION
- Demo overlay now collects name/email/subject/message and posts to /support, button relabeled Request Demo; "Schedule a demo" in CTABanner opens the same overlay via a window event
- Header Upgrade link no longer forces option=byok; users land on their current tier sub-tab
- BillingConfig preserves preferred-model selections across tab switches and only renders the model picker + warning on the tier the user is subscribed to
- Billing page hides "Billing Interval" for one-time plans (gyok/topup) and collapses Start/End Date into a single "Period" column showing "One-time" for those plans
- support-messages-actions returns {ok,error} instead of calling server-side alert() and uses the trailing-slash path