### PR TITLE
feat(landing): lean the home page into the agent framing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -63,7 +63,7 @@ export default function Home() {
               className="inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full bg-gradient-to-r from-blue-50 to-indigo-50 border border-blue-100/60 text-blue-700 text-[10px] sm:text-[11px] font-bold uppercase tracking-[0.15em] mb-6 shadow-sm"
             >
               <Sparkles size={13} className="animate-spin-slow" />
-              Document intelligence platform
+              AI agents for every document
             </motion.div>
 
             {/* Headline */}
@@ -71,11 +71,11 @@ export default function Home() {
               variants={itemVariants}
               className="text-[2.25rem] leading-[1.05] sm:text-6xl lg:text-7xl font-black tracking-tight text-gray-900 mb-5"
             >
-              Every document.{" "}
+              An AI agent for{" "}
               <span className="bg-clip-text text-transparent bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600">
-                Understood.
+                every document
               </span>{" "}
-              Instantly.
+              you handle.
             </motion.h1>
 
             {/* Concrete subhead */}
@@ -83,9 +83,9 @@ export default function Home() {
               variants={itemVariants}
               className="max-w-xl text-base sm:text-lg text-gray-500 mb-8 leading-relaxed"
             >
-              Upload invoices, contracts, purchase orders, bank statements, or budgets. Cellilox
-              scans, classifies, and extracts every field — then makes it all queryable in plain
-              language.
+              Pick a document type — invoices, contracts, purchase orders, bank statements, and
+              more — and spin up an AI agent that reads every file you drop in. Upload, email it
+              in, or share a link. Then ask anything in plain language.
             </motion.p>
 
             {/* CTAs */}
@@ -97,7 +97,7 @@ export default function Home() {
                 href="/dashboard"
                 className="group relative inline-flex items-center justify-center gap-2.5 bg-gray-900 text-white font-semibold py-3.5 px-7 rounded-xl shadow-xl shadow-gray-900/15 hover:bg-blue-600 transition-all hover:scale-[1.02] active:scale-95 text-sm sm:text-base"
               >
-                Start for free
+                Create your first agent
                 <ArrowRight size={17} className="group-hover:translate-x-1 transition-transform" />
               </Link>
               <div>

--- a/src/components/landing/CTABanner.tsx
+++ b/src/components/landing/CTABanner.tsx
@@ -45,14 +45,14 @@ export default function CTABanner() {
                 Get started today
               </div>
               <h2 className="text-4xl font-black leading-tight tracking-tight text-white sm:text-5xl">
-                Stop managing <br className="hidden sm:block" />
+                Stop processing <br className="hidden sm:block" />
                 <span className="bg-gradient-to-r from-blue-400 via-indigo-400 to-purple-400 bg-clip-text text-transparent">
                   documents manually.
                 </span>
               </h2>
               <p className="mt-5 max-w-lg text-base leading-relaxed text-white/55">
-                Join 500+ businesses across East Africa that turned document chaos into structured,
-                queryable, actionable data. Free to start — no setup, no credit card.
+                Let an AI agent extract every field, answer every question, and keep up while you
+                sleep. Free to start — no setup, no credit card.
               </p>
             </div>
 
@@ -61,7 +61,7 @@ export default function CTABanner() {
                 href="/dashboard"
                 className="group inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-blue-500 to-indigo-500 px-8 py-4 text-sm font-bold text-white shadow-lg shadow-blue-500/30 transition-all hover:scale-[1.02] hover:shadow-xl hover:shadow-blue-500/40"
               >
-                Create your free account
+                Build your first agent
                 <ArrowRight size={16} className="transition-transform group-hover:translate-x-1" />
               </Link>
               <button

--- a/src/components/landing/DocumentTypesGrid.tsx
+++ b/src/components/landing/DocumentTypesGrid.tsx
@@ -83,13 +83,13 @@ export default function DocumentTypesGrid() {
           transition={{ duration: 0.6 }}
           className="max-w-2xl"
         >
-          <SectionEyebrow>What we handle</SectionEyebrow>
+          <SectionEyebrow>Ready-made agents</SectionEyebrow>
           <h2 className="text-4xl font-black tracking-tight text-gray-900 sm:text-5xl">
-            One platform for <span className="bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 bg-clip-text text-transparent">every business document</span>
+            One agent for <span className="bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 bg-clip-text text-transparent">every business document</span>
           </h2>
           <p className="mt-4 text-base leading-relaxed text-gray-500 sm:text-lg">
-            Finance, logistics, supply chain, procurement — if it&apos;s a document your business
-            generates or receives, Cellilox understands it.
+            Finance, logistics, supply chain, procurement — pick a document type and your agent
+            is live in seconds. Bring your own type with Custom.
           </p>
         </motion.div>
 

--- a/src/components/landing/HowItWorks.tsx
+++ b/src/components/landing/HowItWorks.tsx
@@ -9,15 +9,15 @@ const STEPS = [
   {
     num: "01",
     icon: Upload,
-    title: "Upload any document",
-    desc: "Drag and drop PDFs, scans, images, or spreadsheets. Forward by email, or connect Google Drive, Dropbox, or your ERP.",
-    details: ["PDF, JPEG, PNG, XLSX, DOCX", "Any language, any currency", "Bulk upload supported"],
+    title: "Pick a document type, get an agent",
+    desc: "Choose Invoices, Receipts, Bank Statements, Contracts — or describe a custom one. Your agent is ready in seconds.",
+    details: ["12+ document types out of the box", "Custom agents for niche workflows", "Files arrive via upload, email, or shared link"],
   },
   {
     num: "02",
     icon: Brain,
-    title: "AI extracts and structures",
-    desc: "Our extraction engine reads every field, identifies document type, validates data, and stores it in a clean queryable database.",
+    title: "Agent extracts and structures",
+    desc: "The agent reads every page, identifies fields, validates data, and stores it in a clean queryable spreadsheet — automatically.",
     details: ["99.4% extraction accuracy", "Under 2 seconds per document", "Automatic duplicate detection"],
   },
   {


### PR DESCRIPTION
Now that the product creates AI Agents (not just 'projects'), the landing page should reflect that. Four focused copy edits, no structural changes:

- Hero pill 'Document intelligence platform' -> 'AI agents for every document'.
- Hero headline 'Every document. Understood. Instantly.' -> 'An AI agent for every document you handle.'
- Hero subhead now leads with the picker -> agent flow and the three real ingestion channels (upload / email / shared link).
- Hero primary CTA 'Start for free' -> 'Create your first agent'.
- HowItWorks step 1 'Upload any document' -> 'Pick a document type, get an agent', and step 2 reframed around 'the agent extracts'.
- DocumentTypesGrid eyebrow 'What we handle' -> 'Ready-made agents'; heading 'One platform for every business document' -> 'One agent for every business document'; subhead mentions the Custom escape hatch.
- CTABanner heading 'Stop managing documents manually' -> 'Stop processing documents manually' with a subhead naming the agent; primary button text 'Create your free account' -> 'Build your first agent'.

No layout changes, no new components, no behavior changes — pure copy.