### PR TITLE
feat(quota): show user-local countdown in daily-doc limit modal

### DIFF
--- a/src/components/modals/GlobalUsageLimitHandler.tsx
+++ b/src/components/modals/GlobalUsageLimitHandler.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState, useCallback, useRef } from 'react'
 import { usePathname, useParams } from 'next/navigation'
 import UsageLimitModal from './UsageLimitModal'
 import { io, Socket } from 'socket.io-client'
+import { extractIso, formatRemainingDuration } from '@/lib/format-time'
 
 export default function GlobalUsageLimitHandler() {
     const [isOpen, setIsOpen] = useState(false)
@@ -38,7 +39,18 @@ export default function GlobalUsageLimitHandler() {
             setIsOpen(true)
         } else if (cleanMsg === 'QUOTA_DAILY_LIMIT' || cleanMsg.includes('Daily extraction limit')) {
             setType('DAILY_LIMIT')
-            setMessage('Daily document limit reached. Your Free plan allows 3 documents every 24 hours. Upgrade for unlimited access.')
+            // Daxno: backend now embeds an ISO-8601 reset_at in the message.
+            // When present, surface it as a user-local countdown ("come back in
+            // 23h, 40min, 30sec") so the modal communicates the actual wait.
+            const iso = extractIso(cleanMsg)
+            const tail = iso
+                ? ` Come back in ${formatRemainingDuration(iso)}.`
+                : ''
+            setMessage(
+                'Daily document limit reached. Your Free plan allows 3 documents every 24 hours.' +
+                tail +
+                ' Upgrade for unlimited access.'
+            )
             setCurrentTier('standard')
             setIsOpen(true)
         } else if (cleanMsg === 'QUOTA_PAGE_LIMIT' || cleanMsg.includes('Monthly page quota') || cleanMsg.includes('exceeds your remaining limit')) {

--- a/src/lib/format-time.ts
+++ b/src/lib/format-time.ts
@@ -1,0 +1,53 @@
+// Daxno: human-friendly formatting for backend ISO timestamps embedded in
+// error / quota toast messages (e.g. "come back <ISO>").
+//
+// Mirrors `daxno-rag/web/src/lib/format-time.ts` so the two surfaces show
+// the same countdown style. Keep them in sync if you tweak one.
+
+// ISO 8601 with timezone (Z or +HH:MM). Matches what `datetime.isoformat()`
+// emits for a timezone-aware datetime, including microsecond variants.
+const ISO_8601_TZ =
+  /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})/;
+
+/**
+ * Format the remaining time until an ISO timestamp as a coarse countdown:
+ *   - "23h, 59min, 34sec"
+ *   - "0h, 5min, 12sec"
+ *   - "any moment" if the target is in the past
+ *
+ * Snapshot at the moment the function is called. Returns the raw ISO
+ * unchanged if parsing fails — never throws.
+ */
+export function formatRemainingDuration(iso: string): string {
+  const target = new Date(iso);
+  if (isNaN(target.getTime())) return iso;
+
+  const ms = target.getTime() - Date.now();
+  if (ms <= 0) return "any moment";
+
+  const totalSec = Math.floor(ms / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  return `${h}h, ${m}min, ${s}sec`;
+}
+
+/**
+ * Extract the first ISO 8601 timestamp from a string, returning it (so you can
+ * format it yourself) or `null` if none is present.
+ */
+export function extractIso(message: string): string | null {
+  const match = message.match(ISO_8601_TZ);
+  return match ? match[0] : null;
+}
+
+/**
+ * Replace the first ISO 8601 timestamp inside a message with the remaining
+ * duration until that timestamp ("23h, 59min, 34sec"). If no ISO is found,
+ * returns the input unchanged.
+ */
+export function localizeIsoInMessage(message: string): string {
+  const iso = extractIso(message);
+  if (!iso) return message;
+  return message.replace(iso, formatRemainingDuration(iso));
+}


### PR DESCRIPTION
GlobalUsageLimitHandler now extracts the backend's embedded ISO-8601 reset_at and appends "Come back in 23h, 40min, 30sec." to the modal copy instead of dropping the timing info entirely. New src/lib/format-time.ts mirrors the daxno-rag helper so the two surfaces show the same countdown format. Backend message stays grammatical when the ISO is absent (falls back to "try again soon").