### PR TITLE
fix(byok): clear masked input on focus, invalidate Verified on edit, …

### DIFF
--- a/src/components/billing/BYOKConfig.tsx
+++ b/src/components/billing/BYOKConfig.tsx
@@ -3,6 +3,15 @@ import { ModelInfo } from '../Models';
 import { verifyProviderKey } from '@/actions/settings-actions';
 import { CheckCircleIcon, XCircleIcon, KeyIcon } from 'lucide-react';
 
+// Strings the backend treats as "user did NOT re-type the key, keep
+// the existing stored value". Must mirror `MASKED_SENTINEL` in
+// daxno-backend/src/tenants/byok_validation.py — typing into a masked
+// input was the May-23 regression: the form ended up submitting
+// e.g. "••••••••X" which the backend then encrypted verbatim, and
+// OpenRouter rejected with 401 Missing Authentication header.
+const MASKED_VALUES = ['••••••••', '********'];
+const MASK_CHARS_REGEX = /[*•●·∙]/;
+
 interface BYOKConfigProps {
     apiKey: string;
     setApiKey: (key: string) => void;
@@ -49,8 +58,45 @@ export default function BYOKConfig({
 
 
 
+    // Clear the masked placeholder the instant the input gets focus so
+    // the user can't accidentally type ON TOP of it. Without this the
+    // browser keeps "••••••••" in the field, appends typed chars, and
+    // we end up submitting "••••••••sk-or-v1-...". The backend now
+    // rejects that with 400, but invalidating it at the source removes
+    // the round-trip and the confused-user experience.
+    const handleApiKeyFocus = () => {
+        if (MASKED_VALUES.includes(apiKey)) {
+            setApiKey('');
+            setIsVerified(false);
+            setSuccessMessage(null);
+        }
+    };
+
+    // Any edit to the input invalidates a stale `Verified` badge. The
+    // user must press Verify again before saving, and the backend now
+    // re-verifies on save anyway. Both layers guard the same invariant.
+    const handleApiKeyChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const next = e.target.value;
+        setApiKey(next);
+        if (isVerified) {
+            setIsVerified(false);
+        }
+    };
+
     const handleVerify = async () => {
         if (!apiKey || !provider) return;
+
+        // Catch the masked-mix case client-side so the user gets a clear
+        // error instead of an opaque 400 from the backend. The backend
+        // enforces the same rule as defence in depth.
+        if (MASK_CHARS_REGEX.test(apiKey)) {
+            setError(
+                "API key contains masking characters (* or •). Open your provider " +
+                "dashboard, copy the full key in plain text, then re-paste it."
+            );
+            setIsVerified(false);
+            return;
+        }
 
         setIsVerifying(true);
         setError(null);
@@ -132,8 +178,9 @@ export default function BYOKConfig({
                         <input
                             type="password"
                             value={apiKey}
-                            onChange={(e) => setApiKey(e.target.value)}
-                            placeholder={apiKey === '••••••••' ? '••••••••' : `sk-...`}
+                            onChange={handleApiKeyChange}
+                            onFocus={handleApiKeyFocus}
+                            placeholder={MASKED_VALUES.includes(apiKey) ? '••••••••' : `sk-...`}
                             className="flex-1 border border-gray-300 rounded-lg p-2 text-sm focus:ring-customBlue focus:border-customBlue"
                         />
                         <button


### PR DESCRIPTION
…reject mask chars on verify

Frontend half of the BYOK-key regression first hit on 2026-05-23 (silent 401s from OpenRouter, every record showing "Not Found" after a save). Root cause was a UI/state mismatch: the masked input held "••••••••", the user typed into it, the form submitted "••••••••sk-or-v1-...", and the backend encrypted it verbatim. The "Verified" badge stayed green because it was set by a PREVIOUS successful verify and nothing on the client invalidated it when the input changed.

Three small surgical changes in BYOKConfig.tsx — no other component touched, no new dependencies, no schema changes:

1. handleApiKeyFocus — when the input gains focus and the current value is one of the known mask sentinels ("••••••••" / "********"), clear it and reset `isVerified`. This guarantees the user can never type ON TOP of the mask — they always start with an empty field.

2. handleApiKeyChange — any edit invalidates a stale Verified state. The user must press Verify again before the green badge can return. Paired with the backend's mandatory re-verify on /billing-config (companion PR Thiernope/daxno-backend#fix/billing-config-revalidate-byok-key), the two layers guard the same invariant.

3. handleVerify client-side guard — if the input contains any mask character (* • ● · ∙), refuse to call the verify endpoint and show a clear inline error pointing the user to re-paste from the provider dashboard. The backend now 400s on the same shape; this just removes the round-trip and gives the user immediate feedback.

The MASKED_VALUES / MASK_CHARS_REGEX constants are documented as mirroring the backend's `MASKED_SENTINEL` / `MASK_CHARS` in `daxno-backend/src/tenants/byok_validation.py` — if a future change adds a new mask char, update both sides together.

Type-checked: `npx tsc --noEmit` exit 0.
Manual smoke flow:
  - Load page with stored key → input shows "••••••••" disabled, badge green.
  - Focus the input → it clears, badge goes back to "Verify".
  - Type a real key → Verify lights up.
  - Paste "* sk-or-v1-..." and click Verify → inline error, no API call.
  - Paste clean key → Verify hits backend, success → "Connected!" message.