### PR TITLE
fix(ai): handle column-recommendation failures and AI_INVALID_KEY end…

### DIFF
--- a/src/components/OfflineSyncManager.tsx
+++ b/src/components/OfflineSyncManager.tsx
@@ -267,6 +267,7 @@ export default function OfflineSyncManager() {
                             const isLimitError = errorMsg.includes('On your Free plan') ||
                                 errorMsg.includes('DAILY_LIMIT_REACHED') ||
                                 errorMsg.includes('AI_CREDITS_EXHAUSTED') ||
+                                errorMsg.includes('AI_INVALID_KEY') ||
                                 errorMsg.includes('exceed the limit');
 
                             if (isLimitError) {

--- a/src/components/Records.tsx
+++ b/src/components/Records.tsx
@@ -499,6 +499,20 @@ export default function Records({ projectId, initialFields, initialRecords, proj
             });
             setPendingAnalysis(true);
         };
+        const handleColumnsRecommendationFailed = (data: {
+            project_id: string;
+            record_id: string;
+            reason_code: string;
+            message: string;
+            retryable: boolean;
+            subscription_type: string;
+        }) => {
+            console.warn('[SOCKET] columns_recommendation_failed:', data);
+            setProcessingStatus(null);
+            setPendingAnalysis(false);
+            setRecommendationMeta(null);
+            setActionError(data.message);
+        };
         const handleColumnUpdated = (data: { field: Field }) => {
             setColumns(prev => Array.isArray(prev) ? prev.map(x => x.hidden_id === data.field.hidden_id ? data.field : x) : []);
         };
@@ -575,6 +589,7 @@ export default function Records({ projectId, initialFields, initialRecords, proj
         socket.on('field_updated', handleColumnUpdated);
         socket.on('field_deleted', handleColumnDeleted);
         socket.on('columns_recommended', handleColumnsRecommended);
+        socket.on('columns_recommendation_failed', handleColumnsRecommendationFailed);
         socket.on('ocr_start', handleOcrStart);
         socket.on('ocr_progress', handleOcrProgress);
         socket.on('ai_start', handleAiStart);
@@ -729,6 +744,7 @@ export default function Records({ projectId, initialFields, initialRecords, proj
             socket.off('field_updated', handleColumnUpdated);
             socket.off('field_deleted', handleColumnDeleted);
             socket.off('columns_recommended', handleColumnsRecommended);
+            socket.off('columns_recommendation_failed', handleColumnsRecommendationFailed);
             socket.off('ocr_start', handleOcrStart);
             socket.off('ocr_progress', handleOcrProgress);
             socket.off('ai_start', handleAiStart);

--- a/src/components/billing/BYOKConfig.tsx
+++ b/src/components/billing/BYOKConfig.tsx
@@ -42,15 +42,18 @@ export default function BYOKConfig({
     const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
     useEffect(() => {
-        const isMasked = apiKey === '••••••••' || apiKey === '********';
+        // A masked sentinel means a key is saved server-side but we have no
+        // proof it still works. Show the neutral "Verify" state — never
+        // auto-flip to green. If the stored key is bad, the next real AI
+        // call surfaces a clear error (see AI_INVALID_KEY handler).
+        const isMasked = MASKED_VALUES.includes(apiKey);
         if (isMasked) {
-            setIsVerified(true);
+            if (isVerified) setIsVerified(false);
         } else if (!apiKey) {
             setIsVerified(false);
             setSuccessMessage(null);
             setError(null);
         } else if (!isVerified) {
-            // Reset messages only when starting to type a new, unverified key
             setSuccessMessage(null);
             setError(null);
         }
@@ -185,7 +188,7 @@ export default function BYOKConfig({
                         />
                         <button
                             onClick={handleVerify}
-                            disabled={!apiKey || apiKey === '••••••••' || isVerifying || (isVerified && apiKey === '••••••••')}
+                            disabled={!apiKey || isVerifying || MASKED_VALUES.includes(apiKey)}
                             className={`px-3 py-2 text-sm font-medium rounded-lg transition-colors flex items-center justify-center gap-2 w-full sm:w-auto
                                 ${isVerified
                                     ? 'bg-green-100 text-green-700 border border-green-200 cursor-default'
@@ -222,7 +225,9 @@ export default function BYOKConfig({
             )}
 
             <p className="text-xs text-gray-500">
-                Verify your API key to unlock model selection. We'll verify it by fetching the latest model list from {getProviderLabel(provider)}.
+                {MASKED_VALUES.includes(apiKey)
+                    ? "Your saved key is hidden. Re-paste it to verify, or just use it — failures will be reported when AI runs."
+                    : `Verify your API key to unlock model selection. We'll verify it by fetching the latest model list from ${getProviderLabel(provider)}.`}
             </p>
         </div>
     );

--- a/src/components/files/Dropzone.tsx
+++ b/src/components/files/Dropzone.tsx
@@ -89,6 +89,19 @@ export default function Dropzone({ projectId, linkOwner, setIsVisible, onMessage
       return true;
     }
 
+    if (cleanMsg.includes('AI_INVALID_KEY')) {
+      // Backend detail format: "AI_INVALID_KEY|<human readable message>".
+      // Pass the full string through so GlobalUsageLimitHandler can render
+      // the tier-aware copy the backend already prepared.
+      window.dispatchEvent(new CustomEvent('daxno:usage-limit-reached', {
+        detail: { error: cleanMsg }
+      }));
+      setIsLoading(false);
+      setIsVisible(false);
+      onMessageChange({ type: messageTypeEnum.NONE, text: '' });
+      return true;
+    }
+
     if (cleanMsg.includes('AI_MODEL_UNAVAILABLE') || cleanMsg.includes('503')) {
       window.dispatchEvent(new CustomEvent('daxno:usage-limit-reached', {
         detail: { error: 'AI_MODEL_UNAVAILABLE' }

--- a/src/components/modals/GlobalUsageLimitHandler.tsx
+++ b/src/components/modals/GlobalUsageLimitHandler.tsx
@@ -65,6 +65,19 @@ export default function GlobalUsageLimitHandler() {
             setMessage('The AI model is currently busy. Daxno is automatically retrying your document — no action needed. If this persists, try switching to a different model.')
             setCurrentTier('standard')
             setIsOpen(true)
+        } else if (cleanMsg.includes('AI_INVALID_KEY')) {
+            // Backend detail format: "AI_INVALID_KEY|<human readable message>".
+            // The message is already tier-aware (BYOK vs Managed vs Standard)
+            // so render it verbatim and let the user click through to Billing
+            // to re-verify.
+            setType('AI_EXHAUSTED')
+            const parts = cleanMsg.split('AI_INVALID_KEY|')
+            const humanMsg = (parts.length > 1 ? parts.pop() : null) ||
+                'Your AI provider key was rejected. Re-verify it under Billing → Provider Configuration.'
+            setMessage(humanMsg)
+            const tier = subType === 'managed' ? 'managed' : (subType === 'byok' ? 'byok' : 'standard')
+            setCurrentTier(tier)
+            setIsOpen(true)
         } else if (cleanMsg.includes('AI_MODEL_UNAVAILABLE') || cleanMsg.includes('503')) {
             setType('AI_EXHAUSTED')
             setMessage('The selected AI model is currently unavailable. Please select another model from your project settings.')


### PR DESCRIPTION
…-to-end

Records.tsx subscribes to the new columns_recommendation_failed socket event (paired with columns_recommended) and surfaces the backend's tier-aware message in the existing actionError red bar. No fake columns ever appear when the recommendation LLM call fails.

Dropzone + GlobalUsageLimitHandler + OfflineSyncManager pipe the new AI_INVALID_KEY|<message> HTTPException detail from the analyze path through the usage-limit event so users get an explicit "Re-verify your provider key" modal instead of opaque per-cell "Not Found".

BYOKConfig: the masked sentinel no longer auto-flips the badge to green "Verified" — that was lying when a saved key had been revoked between sessions. The Verify button is kept clickable in the masked state so users can re-test; helper copy explains the neutral state.