### PR TITLE
feat(admin): surface awaiting-analysis backlog on /admin/onyx-sync

### DIFF
--- a/src/actions/admin-actions.ts
+++ b/src/actions/admin-actions.ts
@@ -99,6 +99,11 @@ export type OnyxSyncHealth = {
   stuck_records_count: number;
   stuck_projects_count: number;
   stuck_projects_by_state: Record<string, number>;
+  // Records uploaded but stranded in `__status__ == "awaiting_analysis"`
+  // for more than the sweeper's grace window. Image rows in this state
+  // defer their Onyx file upload until backfill runs; a non-zero value
+  // here usually means a column-add or backfill never completed.
+  awaiting_analysis_count?: number;
 };
 
 export async function getOnyxSyncHealth(): Promise<OnyxSyncHealth | null> {

--- a/src/actions/admin-actions.ts
+++ b/src/actions/admin-actions.ts
@@ -104,6 +104,28 @@ export type OnyxSyncHealth = {
   // defer their Onyx file upload until backfill runs; a non-zero value
   // here usually means a column-add or backfill never completed.
   awaiting_analysis_count?: number;
+  // E.3 — open audit rows for delete tasks that exhausted Celery
+  // retries. Non-zero means a record was deleted in daxno but the
+  // corresponding Onyx file still survives. Sweeper retries on a
+  // 15min→1h→4h→24h backoff; admin can also force a retry per row.
+  pending_cleanup_count?: number;
+};
+
+export type CleanupFailureRow = {
+  id: number;
+  record_id: string;
+  project_id: string;
+  filename: string;
+  error: string | null;
+  attempts: number;
+  next_retry_at: string | null;
+  created_at: string | null;
+};
+
+export type CleanupFailuresResponse = {
+  items: CleanupFailureRow[];
+  limit: number;
+  offset: number;
 };
 
 export async function getOnyxSyncHealth(): Promise<OnyxSyncHealth | null> {
@@ -119,6 +141,57 @@ export async function getOnyxSyncHealth(): Promise<OnyxSyncHealth | null> {
   } catch (err) {
     console.error("[admin-actions] onyx-sync/health error:", err);
     return null;
+  }
+}
+
+
+export async function getCleanupFailures(
+  limit = 50,
+  offset = 0,
+): Promise<CleanupFailuresResponse | null> {
+  try {
+    const res = await fetchAuthed(
+      buildApiUrl(
+        `/admin/onyx-sync/cleanup-failures?limit=${limit}&offset=${offset}`,
+      ),
+    );
+    if (!res.ok) {
+      console.error(
+        `[admin-actions] cleanup-failures list failed: ${res.status} ${res.statusText}`,
+      );
+      return null;
+    }
+    return (await res.json()) as CleanupFailuresResponse;
+  } catch (err) {
+    console.error("[admin-actions] cleanup-failures list error:", err);
+    return null;
+  }
+}
+
+
+export type RetryCleanupResult =
+  | { ok: true; id: number; record_id: string }
+  | { ok: false; error: string };
+
+export async function retryCleanupFailure(
+  rowId: number,
+): Promise<RetryCleanupResult> {
+  try {
+    const res = await fetchAuthed(
+      buildApiUrl(`/admin/onyx-sync/cleanup-failures/${rowId}/retry`),
+      { method: "POST" },
+    );
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      return {
+        ok: false,
+        error: `Retry failed (${res.status}): ${body || res.statusText}`,
+      };
+    }
+    const data = (await res.json()) as { id: number; record_id: string };
+    return { ok: true, id: data.id, record_id: data.record_id };
+  } catch (err: any) {
+    return { ok: false, error: err?.message ?? "Network error" };
   }
 }
 

--- a/src/components/admin/OnyxSyncDashboard.tsx
+++ b/src/components/admin/OnyxSyncDashboard.tsx
@@ -7,6 +7,7 @@ import {
   Activity,
   FileWarning,
   FolderX,
+  Hourglass,
   RefreshCw,
   ChevronLeft,
 } from "lucide-react";
@@ -104,10 +105,14 @@ export default function OnyxSyncDashboard({ initial }: OnyxSyncDashboardProps) {
   const failures24h = data.failures_last_24h ?? 0;
   const stuckRecords = data.stuck_records_count ?? 0;
   const stuckProjects = data.stuck_projects_count ?? 0;
+  const awaitingAnalysis = data.awaiting_analysis_count ?? 0;
 
   const failuresTone = tone(failures24h, 5, 50);
   const recordsTone = tone(stuckRecords, 1, 20);
   const projectsTone = tone(stuckProjects, 1, 5);
+  // Awaiting-analysis is informational, not a failure. A small backlog
+  // is normal during column setup; a large one signals a stalled flow.
+  const awaitingTone = tone(awaitingAnalysis, 5, 50);
 
   // 7-day data: sort by date ASC for the sparkline
   const dayEntries = Object.entries(data.failures_by_day_last_7d ?? {}).sort();
@@ -158,7 +163,7 @@ export default function OnyxSyncDashboard({ initial }: OnyxSyncDashboardProps) {
           </div>
         )}
 
-        <section className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
           <KpiCard
             label="Failures · last 24h"
             value={failures24h.toString()}
@@ -182,6 +187,14 @@ export default function OnyxSyncDashboard({ initial }: OnyxSyncDashboardProps) {
             Icon={FolderX}
             tone={projectsTone}
             testid="card-stuck-projects"
+          />
+          <KpiCard
+            label="Awaiting analysis"
+            value={awaitingAnalysis.toString()}
+            sub="uploaded but no columns yet · image rows defer Onyx upload"
+            Icon={Hourglass}
+            tone={awaitingTone}
+            testid="card-awaiting-analysis"
           />
         </section>
 

--- a/src/components/admin/OnyxSyncDashboard.tsx
+++ b/src/components/admin/OnyxSyncDashboard.tsx
@@ -10,10 +10,15 @@ import {
   Hourglass,
   RefreshCw,
   ChevronLeft,
+  Trash2,
+  RotateCw,
 } from "lucide-react";
 import {
   getOnyxSyncHealth,
+  getCleanupFailures,
+  retryCleanupFailure,
   type OnyxSyncHealth,
+  type CleanupFailureRow,
 } from "@/actions/admin-actions";
 
 
@@ -61,21 +66,52 @@ export default function OnyxSyncDashboard({ initial }: OnyxSyncDashboardProps) {
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // E.3 — pending cleanup failures list. Loaded alongside the health
+  // metrics on every refresh so the table stays in sync with the KPI
+  // counter and the per-row retries can be observed near-immediately.
+  const [cleanupRows, setCleanupRows] = useState<CleanupFailureRow[]>([]);
+  const [retryingIds, setRetryingIds] = useState<Set<number>>(new Set());
+
   async function refresh() {
     setRefreshing(true);
     setError(null);
     try {
-      const fresh = await getOnyxSyncHealth();
+      const [fresh, cleanup] = await Promise.all([
+        getOnyxSyncHealth(),
+        getCleanupFailures(50, 0),
+      ]);
       if (fresh) {
         setData(fresh);
         setLoadedAt(new Date());
       } else {
         setError("Backend returned no data — check admin auth or backend logs.");
       }
+      setCleanupRows(cleanup?.items ?? []);
     } catch (e: any) {
       setError(e?.message ?? "Failed to load health data");
     } finally {
       setRefreshing(false);
+    }
+  }
+
+  async function handleRetry(id: number) {
+    setRetryingIds((prev) => new Set(prev).add(id));
+    try {
+      const result = await retryCleanupFailure(id);
+      if (!result.ok) {
+        setError(result.error);
+      } else {
+        // Optimistically drop the row from view; the next refresh
+        // confirms via the live list. If the retry itself fails the
+        // task_failure handler will re-add the row on its next tick.
+        setCleanupRows((rows) => rows.filter((r) => r.id !== id));
+      }
+    } finally {
+      setRetryingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
     }
   }
 
@@ -84,6 +120,12 @@ export default function OnyxSyncDashboard({ initial }: OnyxSyncDashboardProps) {
   useEffect(() => {
     const id = setInterval(refresh, 30_000);
     return () => clearInterval(id);
+  }, []);
+
+  // First-mount fetch of the cleanup-failures list (the initial health
+  // payload comes from the server component but the list does not).
+  useEffect(() => {
+    getCleanupFailures(50, 0).then((c) => setCleanupRows(c?.items ?? []));
   }, []);
 
   if (!data) {
@@ -106,6 +148,7 @@ export default function OnyxSyncDashboard({ initial }: OnyxSyncDashboardProps) {
   const stuckRecords = data.stuck_records_count ?? 0;
   const stuckProjects = data.stuck_projects_count ?? 0;
   const awaitingAnalysis = data.awaiting_analysis_count ?? 0;
+  const pendingCleanup = data.pending_cleanup_count ?? 0;
 
   const failuresTone = tone(failures24h, 5, 50);
   const recordsTone = tone(stuckRecords, 1, 20);
@@ -113,6 +156,10 @@ export default function OnyxSyncDashboard({ initial }: OnyxSyncDashboardProps) {
   // Awaiting-analysis is informational, not a failure. A small backlog
   // is normal during column setup; a large one signals a stalled flow.
   const awaitingTone = tone(awaitingAnalysis, 5, 50);
+  // Pending cleanup is always actionable — every row is a delete that
+  // didn't fully complete on the Onyx side. Even one row is worth
+  // noticing, so the warn threshold is 1.
+  const cleanupTone = tone(pendingCleanup, 1, 20);
 
   // 7-day data: sort by date ASC for the sparkline
   const dayEntries = Object.entries(data.failures_by_day_last_7d ?? {}).sort();
@@ -163,7 +210,7 @@ export default function OnyxSyncDashboard({ initial }: OnyxSyncDashboardProps) {
           </div>
         )}
 
-        <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+        <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 mb-6">
           <KpiCard
             label="Failures · last 24h"
             value={failures24h.toString()}
@@ -195,6 +242,14 @@ export default function OnyxSyncDashboard({ initial }: OnyxSyncDashboardProps) {
             Icon={Hourglass}
             tone={awaitingTone}
             testid="card-awaiting-analysis"
+          />
+          <KpiCard
+            label="Pending Onyx cleanup"
+            value={pendingCleanup.toString()}
+            sub="delete tasks past Celery retries · sweeper retries on backoff"
+            Icon={Trash2}
+            tone={cleanupTone}
+            testid="card-pending-cleanup"
           />
         </section>
 
@@ -305,6 +360,102 @@ export default function OnyxSyncDashboard({ initial }: OnyxSyncDashboardProps) {
               <code className="px-1 bg-gray-100 rounded">sync_attempts &lt; 20</code>
               {" "}every 15 minutes.
             </p>
+          </div>
+        </section>
+
+        {/* E.3 — Pending Onyx cleanup failures (per-row table) */}
+        <section className="mt-6">
+          <div className="bg-white rounded-xl ring-1 ring-gray-200 p-5 shadow-sm">
+            <div className="flex items-center justify-between mb-3">
+              <h2 className="text-sm font-medium text-gray-700">
+                Pending Onyx cleanup
+              </h2>
+              <span className="text-xs text-gray-400">
+                {cleanupRows.length} shown
+              </span>
+            </div>
+
+            <p className="text-xs text-gray-500 mb-3">
+              These are delete tasks that exhausted Celery&apos;s autoretry
+              budget. The sweeper retries them on a{" "}
+              <code className="px-1 bg-gray-100 rounded">15m → 1h → 4h → 24h</code>
+              {" "}backoff. Use{" "}
+              <strong>Retry now</strong> when you&apos;ve confirmed the underlying
+              Onyx outage is resolved and want immediate cleanup.
+            </p>
+
+            <table className="w-full text-sm">
+              <thead className="text-gray-500">
+                <tr>
+                  <th className="text-left font-medium py-1.5">Filename</th>
+                  <th className="text-left font-medium py-1.5">Project</th>
+                  <th className="text-left font-medium py-1.5">Last error</th>
+                  <th className="text-right font-medium py-1.5">Attempts</th>
+                  <th className="text-right font-medium py-1.5">Next retry</th>
+                  <th className="text-right font-medium py-1.5">Action</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {cleanupRows.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="text-gray-400 italic py-3">
+                      No pending cleanup rows — every delete made it through.
+                    </td>
+                  </tr>
+                ) : (
+                  cleanupRows.map((row) => {
+                    const isRetrying = retryingIds.has(row.id);
+                    const nextRetry = row.next_retry_at
+                      ? new Date(row.next_retry_at).toLocaleString()
+                      : "—";
+                    return (
+                      <tr key={row.id} data-testid={`cleanup-row-${row.id}`}>
+                        <td
+                          className="py-2 text-gray-800 max-w-[260px] truncate"
+                          title={row.filename}
+                        >
+                          {row.filename}
+                        </td>
+                        <td
+                          className="py-2 text-gray-500 font-mono text-xs max-w-[140px] truncate"
+                          title={row.project_id}
+                        >
+                          {row.project_id}
+                        </td>
+                        <td
+                          className="py-2 text-red-700 max-w-[360px] truncate"
+                          title={row.error ?? ""}
+                        >
+                          {row.error ?? "—"}
+                        </td>
+                        <td className="py-2 text-right text-gray-700">
+                          {row.attempts}
+                        </td>
+                        <td className="py-2 text-right text-gray-500 text-xs">
+                          {nextRetry}
+                        </td>
+                        <td className="py-2 text-right">
+                          <button
+                            type="button"
+                            onClick={() => handleRetry(row.id)}
+                            disabled={isRetrying}
+                            className="inline-flex items-center gap-1 rounded-md bg-blue-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+                            data-testid={`retry-button-${row.id}`}
+                          >
+                            <RotateCw
+                              className={`w-3.5 h-3.5 ${
+                                isRetrying ? "animate-spin" : ""
+                              }`}
+                            />
+                            {isRetrying ? "Retrying…" : "Retry now"}
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
           </div>
         </section>
       </div>


### PR DESCRIPTION
Pairs with backend B.4 (daxno-backend f09a2cf0). The /admin/onyx-sync/health response now includes `awaiting_analysis_count` — records uploaded but stuck in __status__=awaiting_analysis for > 10 min.

- `OnyxSyncHealth` type gains the optional field
- 4th KPI card "Awaiting analysis" with Hourglass icon
- Grid switches from sm:grid-cols-3 to sm:grid-cols-2 lg:grid-cols-4 so the 4-card row fits on every breakpoint
- Tone thresholds (warn at 5, bad at 50) — small backlog is normal during column setup, large means a stalled column-add flow