### PR TITLE
feat(seo): add sitemap, robots, metadata, and crawler protection

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,13 +21,56 @@ const geistMono = localFont({
     weight: "100 900",
 });
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://cellilox.com";
+
 export const metadata: Metadata = {
+    metadataBase: new URL(siteUrl),
     title: "Cellilox | Home",
-    description: "Welcome to Cellilox, your smart system for document processing and data entry!",
+    description:
+        "Cellilox spins up an AI agent for every document you handle — invoices, contracts, purchase orders, bank statements and more. Upload, email, or share a link, then ask anything in plain language.",
+    keywords: [
+        "document processing",
+        "AI document agent",
+        "data entry automation",
+        "invoice extraction",
+        "contract analysis",
+        "document AI",
+        "Cellilox",
+    ],
+    alternates: {
+        canonical: "/",
+    },
     icons: {
         icon: "/favicon.ico",
     },
     manifest: "/manifest.json",
+    openGraph: {
+        type: "website",
+        url: siteUrl,
+        siteName: "Cellilox",
+        title: "Cellilox | An AI agent for every document",
+        description:
+            "Pick a document type and spin up an AI agent that reads every file you drop in. Upload, email it in, or share a link — then ask anything in plain language.",
+        images: [
+            {
+                url: "/icons/icon-512.png",
+                width: 512,
+                height: 512,
+                alt: "Cellilox",
+            },
+        ],
+    },
+    twitter: {
+        card: "summary_large_image",
+        title: "Cellilox | An AI agent for every document",
+        description:
+            "Pick a document type and spin up an AI agent that reads every file you drop in. Upload, email it in, or share a link — then ask anything in plain language.",
+        images: ["/icons/icon-512.png"],
+    },
+    robots: {
+        index: true,
+        follow: true,
+    },
 };
 
 export default function RootLayout({

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,27 @@
+import type { MetadataRoute } from "next";
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://cellilox.com";
+
+export default function robots(): MetadataRoute.Robots {
+    return {
+        rules: {
+            userAgent: "*",
+            allow: "/",
+            disallow: [
+                "/dashboard",
+                "/agents",
+                "/admin",
+                "/billing",
+                "/payments",
+                "/accept-invite",
+                "/submissions",
+                "/invite-error",
+                "/offline",
+                "/auth/",
+                "/api/",
+            ],
+        },
+        sitemap: `${siteUrl}/sitemap.xml`,
+        host: siteUrl,
+    };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,40 @@
+import type { MetadataRoute } from "next";
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://cellilox.com";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+    const lastModified = new Date();
+
+    return [
+        {
+            url: `${siteUrl}/`,
+            lastModified,
+            changeFrequency: "weekly",
+            priority: 1.0,
+        },
+        {
+            url: `${siteUrl}/privacy-policy`,
+            lastModified,
+            changeFrequency: "yearly",
+            priority: 0.3,
+        },
+        {
+            url: `${siteUrl}/terms-of-service`,
+            lastModified,
+            changeFrequency: "yearly",
+            priority: 0.3,
+        },
+        {
+            url: `${siteUrl}/cookie-policy`,
+            lastModified,
+            changeFrequency: "yearly",
+            priority: 0.3,
+        },
+        {
+            url: `${siteUrl}/refund-policy`,
+            lastModified,
+            changeFrequency: "yearly",
+            priority: 0.3,
+        },
+    ];
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -20,6 +20,17 @@ export default clerkMiddleware(async (auth, req) => {
     // We allow the document to load so that the Service Worker can serve the cache.
     // Online users will still be redirected by Clerk's client-side components.
     if (!userId) {
+      // Search crawlers must never get the soft-protection bypass, otherwise
+      // they index empty shells of protected app pages. Force them through
+      // auth.protect() (→ redirect to sign-in). Real users never send these
+      // user-agents, so offline PWA behavior is unaffected.
+      const userAgent = req.headers.get('user-agent')?.toLowerCase() || '';
+      const isBot = userAgent.includes('googlebot') || userAgent.includes('bingbot') || userAgent.includes('baiduspider');
+      if (isBot) {
+        await auth.protect();
+        return;
+      }
+
       const isDocumentRequest = req.headers.get('sec-fetch-dest') === 'document';
       if (isDocumentRequest) return;
 


### PR DESCRIPTION
- app/sitemap.ts: public URLs only (landing + legal pages), absolute https://cellilox.com links from NEXT_PUBLIC_SITE_URL (fallback baked in).
- app/robots.ts: allow /, disallow app/private routes (dashboard, agents, admin, billing, payments, accept-invite, submissions, api, etc.), with Host and Sitemap reference.
- layout.tsx: add metadataBase, canonical, OpenGraph/Twitter cards, and keywords so public pages rank and share cleanly.
- middleware.ts: redirect known crawlers (Googlebot/Bingbot/Baiduspider) through auth.protect() so they never receive the PWA soft-protection document bypass. Real users (online/offline) never match these user-agents, so offline PWA behavior is unchanged.