### PR TITLE
fix: hide billing Save Changes on tiers the user hasn't paid for

### DIFF
--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -45,6 +45,24 @@ export default async function BillingPage() {
     };
   }
 
+  // Tiers the user has actually paid for. Used by BillingConfig to decide
+  // whether to render the "Save Changes" footer on a tab — saving on a tab
+  // the user hasn't paid for was flipping subscription_type without payment.
+  // Standard is always entitled. Managed entitlement comes from any active
+  // gyok/topup transaction OR a stored managed key (subscription_type or
+  // sk-or-daxno key prefix). BYOK entitlement comes from an active BYOK
+  // subscription transaction.
+  const entitledTiers = new Set<string>(['standard']);
+  for (const tx of activeTransactions ?? []) {
+    const name = (tx?.plan_name || '').toString().toLowerCase().trim();
+    if (name === 'byok') entitledTiers.add('byok');
+    if (name === 'gyok' || name === 'topup') entitledTiers.add('managed');
+  }
+  if (billingConfig?.subscription_type === 'managed') entitledTiers.add('managed');
+  if (typeof billingConfig?.byok_api_key === 'string' && billingConfig.byok_api_key.startsWith('sk-or-daxno')) {
+    entitledTiers.add('managed');
+  }
+
   const billingConfigProps = {
     initialConfig: billingConfig,
     trustedModels: trustedModels,
@@ -53,6 +71,7 @@ export default async function BillingPage() {
     currentInterval: subscriptionProps?.subInterval,
     currentAmount: subscriptionProps?.subAmount ? Number(subscriptionProps.subAmount) : (firstTx?.amount ? Number(firstTx.amount) : 0),
     currentEndDate: subscriptionProps?.nextBillingDate || firstTx?.end_date,
+    entitledTiers: Array.from(entitledTiers),
   };
 
   return (

--- a/src/components/BillingConfig.tsx
+++ b/src/components/BillingConfig.tsx
@@ -35,11 +35,12 @@ export interface BillingConfigProps {
     currentInterval?: string;
     currentAmount?: number;
     currentEndDate?: string | Date;
+    entitledTiers?: string[];
 }
 
 const TRUSTED_OPENROUTER_PREFIXES = ['openai/', 'anthropic/', 'google/', 'deepseek/'];
 
-export default function BillingConfig({ initialConfig, allModels, currentPlan, currentInterval, currentAmount, currentEndDate }: BillingConfigProps) {
+export default function BillingConfig({ initialConfig, allModels, currentPlan, currentInterval, currentAmount, currentEndDate, entitledTiers }: BillingConfigProps) {
     // 3 Modes: 'standard', 'byok' (Own Key), 'managed' (GYOMK)
     // Map initialConfig.subscription_type (standard/byok) to one of these.
     // Ideally backend should support 'managed', but for now we might infer or keep 'byok' for both backend-side but separating UI.
@@ -93,6 +94,17 @@ export default function BillingConfig({ initialConfig, allModels, currentPlan, c
 
     const isByokSubscribed = currentSubscriptionTier === 'byok';
     const isViewingCurrentTier = billingType === currentSubscriptionTier;
+    // Tiers the user has paid for. Falls back to the single effective tier
+    // when the prop isn't supplied. Save Changes is hidden on any tab not in
+    // this set — saving on an unpaid tier was flipping subscription_type
+    // without payment via POST /tenants/billing-config.
+    const effectiveEntitledTiers = useMemo<string[]>(
+        () => entitledTiers && entitledTiers.length > 0
+            ? entitledTiers
+            : [currentSubscriptionTier, 'standard'],
+        [entitledTiers, currentSubscriptionTier]
+    );
+    const isEntitledToCurrentTab = effectiveEntitledTiers.includes(billingType);
     const [billingCycle, setBillingCycle] = useState<'monthly' | 'yearly'>('monthly');
 
 
@@ -1218,10 +1230,12 @@ export default function BillingConfig({ initialConfig, allModels, currentPlan, c
                     </>
                 )}
 
-                {/* Save Changes footer — shown for any non-standard tab
-                    (BYOK or Managed) regardless of the user's actual
-                    subscription. Standard has nothing to configure here. */}
-                {billingType !== 'standard' && (
+                {/* Save Changes footer — only shown on tabs the user has
+                    actually paid for. The Subscribe (BYOK) / Buy Credits
+                    (Managed) CTAs above are the correct paths for an
+                    unpaid tier; saving here would have flipped
+                    subscription_type without payment. */}
+                {billingType !== 'standard' && isEntitledToCurrentTab && (
                     <div className="flex items-center justify-between pt-4 border-t border-gray-100">
                         {message && (
                             <span className={`text-sm ${message.type === 'success' ? 'text-green-600' : 'text-red-600'}`}>


### PR DESCRIPTION
The Save footer on the LLM Configuration page was active on every non-standard tab regardless of subscription, so a managed user could open the BYOK tab, click Save, and flip subscription_type to byok without paying. Derive entitledTiers from the full activeTransactions list plus the managed-key signal and gate the Save footer on it. The Subscribe (BYOK) and Buy Credits (Managed) CTAs stay visible on unpaid tabs as the correct paid paths; a user entitled to both byok and managed can still save on either tab.