### PR TITLE
fix(blog): render blog pages dynamically (fixes prod 500)

### DIFF
--- a/src/actions/blog-actions.ts
+++ b/src/actions/blog-actions.ts
@@ -48,7 +48,9 @@ export type BlogPostInput = {
 export async function listPublishedPosts(): Promise<BlogPostListItem[]> {
   try {
     const res = await fetch(buildApiUrl("/blog/posts"), {
-      next: { revalidate: 300, tags: ["blog"] },
+      // Pages are force-dynamic; fetch fresh each render. Avoids writing the
+      // prerender/fetch cache (the prod container's .next/cache is read-only).
+      cache: "no-store",
     });
     if (!res.ok) return [];
     return (await res.json()) as BlogPostListItem[];
@@ -61,7 +63,7 @@ export async function listPublishedPosts(): Promise<BlogPostListItem[]> {
 export async function getPublishedPost(slug: string): Promise<BlogPost | null> {
   try {
     const res = await fetch(buildApiUrl(`/blog/posts/${encodeURIComponent(slug)}`), {
-      next: { revalidate: 300, tags: ["blog", `blog:${slug}`] },
+      cache: "no-store",
     });
     if (!res.ok) return null;
     return (await res.json()) as BlogPost;

--- a/src/app/blogs/[slug]/page.tsx
+++ b/src/app/blogs/[slug]/page.tsx
@@ -1,18 +1,17 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { getPublishedPost, listPublishedPosts } from "@/actions/blog-actions";
+import { getPublishedPost } from "@/actions/blog-actions";
 import BlogMarkdown from "@/components/blog/BlogMarkdown";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://cellilox.com";
 
-export const revalidate = 300;
-
-// Pre-render known published slugs at build for instant, crawlable HTML.
-export async function generateStaticParams() {
-  const posts = await listPublishedPosts();
-  return posts.map((p) => ({ slug: p.slug }));
-}
+// Render per request (SSR). The global <Header> calls Clerk auth()/headers(),
+// which is a dynamic API and cannot be statically prerendered — attempting to
+// (via generateStaticParams/revalidate) throws DYNAMIC_SERVER_USAGE in prod.
+// Matches the convention in privacy-policy/page.tsx. Pages are still fully
+// server-rendered HTML for crawlers.
+export const dynamic = "force-dynamic";
 
 type Params = { params: Promise<{ slug: string }> };
 

--- a/src/app/blogs/page.tsx
+++ b/src/app/blogs/page.tsx
@@ -4,9 +4,10 @@ import { listPublishedPosts } from "@/actions/blog-actions";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://cellilox.com";
 
-// Re-render the index every few minutes so new posts surface quickly while still
-// serving fast cached HTML to crawlers and visitors.
-export const revalidate = 300;
+// Render per request (SSR). The global <Header> uses Clerk auth()/headers(),
+// which cannot be statically prerendered — so opt this route into dynamic
+// rendering (matches privacy-policy/page.tsx). New posts surface immediately.
+export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: "Cellilox Blog | Document Automation & AI Data Extraction",


### PR DESCRIPTION
Production 500 on /blogs/[slug]: DYNAMIC_SERVER_USAGE — the route tried to prerender statically (generateStaticParams + revalidate) but the global <Header> uses Clerk auth()/headers(), a dynamic API. Even a missing slug 500d instead of 404 because it failed before the data fetch.

Switch both blog pages to 'force-dynamic' (the convention already used in privacy-policy/page.tsx) and drop generateStaticParams; fetch posts with cache: 'no-store' so nothing writes the read-only .next/cache (the EACCES we also saw). Pages remain fully server-rendered HTML for crawlers.